### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,10 @@
 
         %% REST framework
         {webmachine, ".*",
-         {git, "git://github.com/basho/webmachine", {tag, "1.9.0-mochifix"}}}
+         {git, "git://github.com/basho/webmachine", {tag, "1.9.0-mochifix"}}},
+
+        {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
         ]}.
 
 {eunit_opts,

--- a/src/darklaunch.erl
+++ b/src/darklaunch.erl
@@ -99,8 +99,8 @@ stop_link() ->
 init([]) ->
     %% Assume these are going to be present in the config and crash
     %% if they aren't
-    {ok, ConfigPath} = application:get_env(darklaunch, config),
-    {ok, ReloadTime} = application:get_env(darklaunch, reload_time),
+    ConfigPath = envy:get(darklaunch, config, string),
+    ReloadTime = envy:get(darklaunch, reload_time, non_neg_integer),
     timer:send_interval(ReloadTime, reload_features),
     case load_features(#state{config_path=ConfigPath}) of
         {ok, InitState} ->

--- a/src/darklaunch_app.erl
+++ b/src/darklaunch_app.erl
@@ -36,7 +36,7 @@
 start(_StartType, _StartArgs) ->
     % If the config file is present and writable, or non-existent but writable, go ahead and
     % start up the supervisor.  Otherwise bail out!
-    {ok, ConfigPath} = application:get_env(darklaunch,config),
+    ConfigPath = envy:get(darklaunch,config, string),
     case ensure_accessible_config(ConfigPath) of
         ok ->
             darklaunch_sup:start_link();

--- a/src/darklaunch_sup.erl
+++ b/src/darklaunch_sup.erl
@@ -50,16 +50,12 @@ configure_rest_interface() ->
     end.
 
 read_rest_addr_port() ->
-    case application:get_env(darklaunch, listen_ip) of
-        undefined ->
+    case { envy:get(darklaunch, listen_ip, undefined, string),
+           envy:get(darklaunch, listen_port, undefined, non_neg_integer) } of
+        {Addr, Port} when Addr == undefined orelse Port == undefined ->
             undefined;
-        {ok, Addr} ->
-            case application:get_env(darklaunch, listen_port) of
-                undefined ->
-                    undefined;
-                {ok, Port} ->
-                    error_logger:info_msg("Configuring darklaunch for standalone mode (~s:~p)~n",
-                                          [Addr, Port]),
-                    {Addr, Port}
-            end
-    end.
+        {Addr, Port} ->
+           error_logger:info_msg("Configuring darklaunch for standalone mode (~s:~p)~n",
+                                   [Addr, Port]),
+           {Addr, Port}
+     end.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
