### PR TITLE
Add is_enabled_strict, stop read-through to file based darklaunch

### DIFF
--- a/src/xdarklaunch_req.erl
+++ b/src/xdarklaunch_req.erl
@@ -20,7 +20,8 @@
          get_header/1,
          get_proplist/1,
          is_enabled/2,
-         is_enabled/3
+         is_enabled/3,
+         is_enabled_strict/2
         ]).
 
 -ifdef(TEST).
@@ -106,6 +107,19 @@ is_enabled(Key, #xdarklaunch{values=Dict}) ->
     case dict:find(Key, Dict) of
         {ok, V} -> is_enabled_helper(V);
         error -> false
+    end.
+
+-spec is_enabled_strict(binary(), #xdarklaunch{} | no_header) -> boolean().
+%% @doc Return the boolean value associated with darklaunch key `Key'. If the darklaunch
+%% data does not have a value for `Key', then an error is raised.
+is_enabled_strict(Key, no_header) ->
+    erlang:error({darklaunch_missing_key, Key});
+is_enabled_strict(Key, #xdarklaunch{values = Dict}) ->
+    case dict:find(Key, Dict) of
+        {ok, V} ->
+            is_enabled_helper(V);
+        error ->
+            erlang:error({darklaunch_missing_key, Key})
     end.
 
 %% @doc Fetch the darklaunch value if available, otherwise return a default value

--- a/test/xdarklaunch_req_tests.erl
+++ b/test/xdarklaunch_req_tests.erl
@@ -61,6 +61,20 @@ is_enabled_with_default_value_test_() ->
               ?assertEqual(anything, xdarklaunch_req:is_enabled(<<"c">>, NH, anything))
       end}].
 
+is_enabled_strict_test_() ->
+    Dl = mk_dl(<<"a=1;b=0">>),
+    MT = mk_dl(<<>>),
+    [{"strict access works when value present",
+      [?_assertEqual(true, xdarklaunch_req:is_enabled_strict(<<"a">>, Dl)),
+       ?_assertEqual(false, xdarklaunch_req:is_enabled_strict(<<"b">>, Dl))]},
+     {"strict access throws error when value missing",
+      ?_assertError({darklaunch_missing_key, <<"c">>},
+                    xdarklaunch_req:is_enabled_strict(<<"c">>, Dl))},
+     {"strict access errors for empty header",
+      ?_assertError({darklaunch_missing_key, <<"c">>},
+                    xdarklaunch_req:is_enabled_strict(<<"c">>, MT))}
+    ].
+
 parse_header_test_() ->
     [{"true false 0 1",
       fun() ->


### PR DESCRIPTION
Make xdarklaunch easier to to reason about and fail safe for common case of feature flipping (rather than migration). Add strict mode for migration use where missing config is crash worthy.

details in commit messages.

/cc @manderson26 @sdelano @oferrigni @marcparadise @hosh 
